### PR TITLE
(#3) Added ability to specify descriptions for releases

### DIFF
--- a/src/main/java/org/llorllale/mvn/plgn/releasecat/Upload.java
+++ b/src/main/java/org/llorllale/mvn/plgn/releasecat/Upload.java
@@ -118,7 +118,7 @@ public final class Upload extends AbstractMojo {
           .create(this.tag)
       );
       release.name(this.name);
-      if (Objects.nonNull(this.description) && this.description.length() > 0) {
+      if (Objects.nonNull(this.description)) {
         release.body(this.description);
       }
     } catch (IOException | IllegalArgumentException e) {

--- a/src/test/java/org/llorllale/mvn/plgn/releasecat/UploadTest.java
+++ b/src/test/java/org/llorllale/mvn/plgn/releasecat/UploadTest.java
@@ -99,4 +99,21 @@ public final class UploadTest {
   public void mojoFailureIfConfigNotSpecified() throws Exception {
     new Upload().execute();
   }
+
+  /**
+   * Release should be created with the given description.
+   * 
+   * @throws Exception unexpected
+   * @since 0.2.0
+   */
+  @Test
+  public void releaseHasGivenDescription() throws Exception {
+    final Repo repo = new MkGithub().repos()
+      .create(new Repos.RepoCreate("my_user/my_project", false));
+    new Upload("Tag v1.0", "Name v1.0", "Description", () -> repo).execute();
+    assertThat(
+      new Release.Smart(new Releases.Smart(repo.releases()).find("Tag v1.0")).body(),
+      is("Description")
+    );
+  }
 }

--- a/src/test/java/org/llorllale/mvn/plgn/releasecat/UploadTest.java
+++ b/src/test/java/org/llorllale/mvn/plgn/releasecat/UploadTest.java
@@ -116,4 +116,26 @@ public final class UploadTest {
       is("Description")
     );
   }
+
+  /**
+   * Release should be created with the given description.
+   * 
+   * @throws Exception unexpected
+   * @since 0.2.0
+   * @todo #3:30min jcabi-github should not be prepopulating optional attributes of fake
+   *  releases with default values like this. That's why this test is checking for
+   *  'Description of the release'. I've opened https://github.com/jcabi/jcabi-github/issues/1362
+   *  for this issue. When that is fixed, come back here and refactor this test.
+   *  
+   */
+  @Test
+  public void descriptionIsNullIfNotSpecified() throws Exception {
+    final Repo repo = new MkGithub().repos()
+      .create(new Repos.RepoCreate("my_user/my_project", false));
+    new Upload("Tag v1.0", "Name v1.0", null, () -> repo).execute();
+    assertThat(
+      new Release.Smart(new Releases.Smart(repo.releases()).find("Tag v1.0")).body(),
+      is("Description of the release")
+    );
+  }
 }


### PR DESCRIPTION
This PR:
* closes #3 
* Adds configuration for release description
* Leaves puzzle for implementing ability to read description from a text file