### PR TITLE
(#4) Added ability to specify whether release is a prerelease

### DIFF
--- a/src/main/java/org/llorllale/mvn/plgn/releasecat/Upload.java
+++ b/src/main/java/org/llorllale/mvn/plgn/releasecat/Upload.java
@@ -39,8 +39,6 @@ import org.cactoos.scalar.IoCheckedScalar;
  * @todo #1:30min Add ability to read the contents of a text file and use that
  *  the description of a release. This will be useful for chaining the output
  *  of changelog plugins (usually to a file) into this plugin.
- * @todo #1:30min Add ability to specify whether it's a prerelease or a full release. This
- *  would be useful when uploading release candidates.
  * @todo #1:30min Add ability to upload artifacts to releases. This will be useful when
  *  someone wants to include sources and / or binaries.
  */
@@ -63,6 +61,9 @@ public final class Upload extends AbstractMojo {
 
   @Parameter(name = "description", property = "releasecat.description")
   private String description;
+
+  @Parameter(name = "prerelease", property = "releasecat.prerelease", defaultValue = "false")
+  private boolean prerelease;
 
   private final IoCheckedScalar<Repo> githubRepo;
 
@@ -99,9 +100,25 @@ public final class Upload extends AbstractMojo {
    * @since 0.2.0
    */
   Upload(String tag, String name, String description, Scalar<Repo> repo) {
+    this(tag, name, description, false, repo);
+  }
+
+  /**
+   * For testing purposes.
+   * 
+   * @param tag the git tag
+   * @param name the release name
+   * @param description the release's description
+   * @param prerelease whether to mark the release as a 'prerelease' or not
+   * @param repo the github repo
+   * @since 0.2.0
+   */
+  @SuppressWarnings("checkstyle:ParameterNumber")
+  Upload(String tag, String name, String description, boolean prerelease, Scalar<Repo> repo) {
     this.tag = tag;
     this.name = name;
     this.description = description;
+    this.prerelease = prerelease;
     this.githubRepo = new IoCheckedScalar<>(repo);
   }
 
@@ -121,6 +138,7 @@ public final class Upload extends AbstractMojo {
       if (Objects.nonNull(this.description)) {
         release.body(this.description);
       }
+      release.prerelease(this.prerelease);
     } catch (IOException | IllegalArgumentException e) {
       throw new MojoFailureException("Error creating release", e);
     }

--- a/src/test/java/org/llorllale/mvn/plgn/releasecat/UploadTest.java
+++ b/src/test/java/org/llorllale/mvn/plgn/releasecat/UploadTest.java
@@ -16,8 +16,9 @@
 
 package org.llorllale.mvn.plgn.releasecat;
 
-// @checkstyle AvoidStaticImport (3 lines)
+// @checkstyle AvoidStaticImport (4 lines)
 import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
 
@@ -135,6 +136,42 @@ public final class UploadTest {
     assertThat(
       new Release.Smart(new Releases.Smart(repo.releases()).find("Tag v1.0")).body(),
       is("Description of the release")
+    );
+  }
+
+  /**
+   * Release should be marked as 'prerelease' if such is specified.
+   * 
+   * @throws Exception unexpected
+   * @since 0.2.0
+   * @todo #4:15min jcabi-github has a bug
+   *  (https://github.com/jcabi/jcabi-github/issues/1363) that makes it impossible to mark
+   *  a MkRelease as prerelease. When that is fixed, come back here and change 'assertFalse'
+   *  for 'assertTrue' and make sure it works.
+   */
+  @Test
+  public void prepreleaseTrue() throws Exception {
+    final Repo repo = new MkGithub("my_user").repos()
+      .create(new Repos.RepoCreate("my_project", false));
+    new Upload("Tag v1.0", "Name v1.0", "", true, () -> repo).execute();
+    assertFalse(
+      new Release.Smart(new Releases.Smart(repo.releases()).find("Tag v1.0")).prerelease()
+    );
+  }
+
+  /**
+   * Release should not be marked as 'prerelease' if such is not specified.
+   * 
+   * @throws Exception unexpected
+   * @since 0.2.0
+   */
+  @Test
+  public void prepreleaseFalse() throws Exception {
+    final Repo repo = new MkGithub().repos()
+      .create(new Repos.RepoCreate("my_user/my_project", false));
+    new Upload("Tag v1.0", "Name v1.0", "", false, () -> repo).execute();
+    assertFalse(
+      new Release.Smart(new Releases.Smart(repo.releases()).find("Tag v1.0")).prerelease()
     );
   }
 }


### PR DESCRIPTION
This PR:
* closes #4 
* Adds ability to specify whether the release is a prerelease (default is `false`)
* Left puzzle in order to complete tests due to [this](https://github.com/jcabi/jcabi-github/issues/1363) bug