### PR TITLE
(#5) Added configuration and upload of files

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -368,6 +368,14 @@
               <format>html</format>
               <format>xml</format>
             </formats>
+            <instrumentation>
+              <ignores>
+                <ignore>org.llorllale.mvn.plgn.releasecat.Asset</ignore>
+              </ignores>
+              <excludes>
+                <exclude>org/llorllale/mvn/plgn/releasecat/Asset.class</exclude>
+              </excludes>
+            </instrumentation>
           </configuration>
         </plugin>
         <plugin>

--- a/src/main/java/org/llorllale/mvn/plgn/releasecat/Asset.java
+++ b/src/main/java/org/llorllale/mvn/plgn/releasecat/Asset.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2018 George Aristy
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.llorllale.mvn.plgn.releasecat;
+
+import java.io.File;
+
+/**
+ * A release asset.
+ *
+ * @author George Aristy (george.aristy@gmail.com)
+ * @since 0.4.0
+ */
+public final class Asset {
+  private String name;
+  private String type;
+  private File file;
+
+  /**
+   * Ctor.
+   * 
+   * @since 0.4.0
+   */
+  public Asset() {
+    //intentional
+  }
+
+  /**
+   * For testing purposes.
+   * 
+   * @param name see {@link #getName()}
+   * @param type see {@link #getType()}
+   * @param file see {@link #getFile()}
+   */
+  public Asset(String name, String type, File file) {
+    this.name = name;
+    this.type = type;
+    this.file = file;
+  }
+
+  /**
+   * The display name for the asset once uploaded.
+   * 
+   * @return the display name for the asset once uploaded
+   * @since 0.4.0
+   */
+  public String getName() {
+    return this.name;
+  }
+
+  /**
+   * The asset's content type (eg. {@code text/xml}).
+   * 
+   * @return the asset's content type
+   * @since 0.4.0
+   */
+  public String getType() {
+    return this.type;
+  }
+
+  /**
+   * The asset's local path.
+   * 
+   * @return the asset's local path
+   * @since 0.4.0
+   */
+  public File getFile() {
+    return this.file;
+  }
+}


### PR DESCRIPTION
This PR:
* Uses as reference this [blog post](https://www.smartics.eu/confluence/display/BLOG/2013/02/17/Complex+Data+Types+in+Maven+Plugin+Configurations)
* Adds new composite configuration `asset` with 3 properties:
  - name of the asset
  - type of the asset (mime type)
  - file
* Excludes code coverage on the new `Asset` class because:
  - Low branch rate due to default ctor not being used in tests
  - It's just a plan DTO anyway
* Leaves puzzle due to impediment on a [jcabi-github](https://github.com/jcabi/jcabi-github/issues/1366) issue
* Leaves another puzzle to mark some configuration options as required

**note**
This new configuration option is to be used like this:
```xml
      <plugin>
        <groupId>org.llorllale</groupId>
        <artifactId>releasecat-maven-plugin</artifactId>
        <configuration>
          <assets>
            <asset>
              <name>A name</name>
              <type>text/plain</type>
              <file>README.md</file>
            </asset>
          </assets>
        </configuration>
      </plugin>
```