### PR TITLE
(#10) Fixed UploadTest.prepreleaseTrue() after upgrading to jcabi-github 0.39 (they fixed their bug #1363)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -261,7 +261,7 @@
     <dependency>
       <groupId>com.jcabi</groupId>
       <artifactId>jcabi-github</artifactId>
-      <version>0.38</version>
+      <version>0.39</version>
     </dependency>
     <dependency>
       <groupId>org.cactoos</groupId>

--- a/src/test/java/org/llorllale/mvn/plgn/releasecat/UploadTest.java
+++ b/src/test/java/org/llorllale/mvn/plgn/releasecat/UploadTest.java
@@ -16,11 +16,12 @@
 
 package org.llorllale.mvn.plgn.releasecat;
 
-// @checkstyle AvoidStaticImport (4 lines)
+// @checkstyle AvoidStaticImport (5 lines)
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 
 import com.jcabi.github.Release;
 import com.jcabi.github.ReleaseAsset;
@@ -152,17 +153,13 @@ public final class UploadTest {
    * 
    * @throws Exception unexpected
    * @since 0.2.0
-   * @todo #4:15min jcabi-github has a bug
-   *  (https://github.com/jcabi/jcabi-github/issues/1363) that makes it impossible to mark
-   *  a MkRelease as prerelease. When that is fixed, come back here and change 'assertFalse'
-   *  for 'assertTrue' and make sure it works.
    */
   @Test
   public void prepreleaseTrue() throws Exception {
     final Repo repo = new MkGithub("my_user").repos()
       .create(new Repos.RepoCreate("my_project", false));
     new Upload("Tag v1.0", "Name v1.0", "", true, () -> repo).execute();
-    assertFalse(
+    assertTrue(
       new Release.Smart(new Releases.Smart(repo.releases()).find("Tag v1.0")).prerelease()
     );
   }


### PR DESCRIPTION
This PR:
* solves #10 
* Upgrades to `jcabi-github` v0.39 after they fixed jcabi/jcabi-github#1363