### PR TITLE
(#16) Removed puzzle for #16

### DIFF
--- a/src/main/java/org/llorllale/mvn/plgn/releasecat/Upload.java
+++ b/src/main/java/org/llorllale/mvn/plgn/releasecat/Upload.java
@@ -42,8 +42,6 @@ import org.cactoos.text.TextOf;
  *
  * @author George Aristy (george.aristy@gmail.com)
  * @since 0.1.0
- * @todo #14:30min Replace 'user' with 'org'. The username can already be obtained via jcabi-github
- *  using the token. 'org' must be optional: if specified then it is used as the "user".
  */
 @Mojo(name = "upload", defaultPhase = LifecyclePhase.DEPLOY)
 public final class Upload extends AbstractMojo {


### PR DESCRIPTION
This PR:
* Removes puzzle #16 
* The puzzle was created under the incorrect assumption that the user would always want to push releases to repos under his/her name, or of organizations that he/she belongs to. However, the user may also want to push releases to repos under another user's name.